### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { generateOpaqueToken, hashOpaqueToken, hashPassword, verifyPassword } from "../lib/security.js";
+import rateLimit from "@fastify/rate-limit";
 
 const registerSchema = z.object({
   email: z.string().email(),
@@ -70,6 +71,9 @@ function userView(member: {
 }
 
 export const authRoutes: FastifyPluginAsync = async (app) => {
+  await app.register(rateLimit, {
+    global: false
+  });
   app.post("/auth/register", { preHandler: app.requireRole(["owner", "admin", "manager"]) }, async (request, reply) => {
     const parsed = registerSchema.safeParse(request.body);
     if (!parsed.success) {
@@ -383,11 +387,22 @@ export const authRoutes: FastifyPluginAsync = async (app) => {
     });
   });
 
-  app.post("/auth/change-password", { preHandler: app.authenticate }, async (request, reply) => {
-    const parsed = updatePasswordSchema.safeParse(request.body);
-    if (!parsed.success) {
-      return invalidPayload(reply, parsed.error.issues);
-    }
+  app.post(
+    "/auth/change-password",
+    {
+      preHandler: app.authenticate,
+      config: {
+        rateLimit: {
+          max: 5,
+          timeWindow: "1 minute"
+        }
+      }
+    },
+    async (request, reply) => {
+      const parsed = updatePasswordSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return invalidPayload(reply, parsed.error.issues);
+      }
 
     const member = await prisma.member.findUnique({
       where: { id: request.user.sub },


### PR DESCRIPTION
Potential fix for [https://github.com/vinberg88/github/security/code-scanning/2](https://github.com/vinberg88/github/security/code-scanning/2)

In general, the fix is to add rate limiting to handlers that perform sensitive authorization or expensive operations, so that a client cannot make unlimited rapid requests. With Fastify, this is typically done using the official `@fastify/rate-limit` plugin and attaching per‑route options (e.g., `config: { rateLimit: { max, timeWindow } }`) to the route declaration.

For this specific file, the minimal, best fix without changing existing functionality is:

1. Import and register `@fastify/rate-limit` in this plugin file (since we cannot see or modify the broader app setup). Fastify plugins can register other plugins; `authRoutes` is a `FastifyPluginAsync`, so we can call `app.register(rateLimit, { ... })` at the top of the function.
2. Configure a reasonable rate limit specifically for the `/auth/change-password` route by adding a `config` field with a `rateLimit` object to the route options, leaving other routes’ behavior unchanged.
3. Keep existing authentication (`preHandler: app.authenticate`) and business logic untouched.

Concretely:

- Add an import for `@fastify/rate-limit` at the top of `apps/api/src/routes/auth.ts`.
- Inside `authRoutes`, near the top (before defining routes), call `app.register(rateLimit, { global: false });` so rate limiting is opt‑in per route.
- Modify the `/auth/change-password` route definition on line 386 to include a `config: { rateLimit: { max: 5, timeWindow: "1 minute" } }` (or similar), turning on rate limiting only for that endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
